### PR TITLE
CI: replace validation of zip compression with create-foxglove-extension minimum version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "@actions/core": "1.10.1",
     "@foxglove/tsconfig": "2.0.0",
     "@types/node": "22.0.2",
+    "@types/semver": "7.5.8",
     "jszip": "3.10.1",
+    "semver": "7.6.3",
     "ts-node": "10.9.2",
     "typescript": "5.5.4"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,6 +109,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/semver@npm:7.5.8":
+  version: 7.5.8
+  resolution: "@types/semver@npm:7.5.8"
+  checksum: 10c0/8663ff927234d1c5fcc04b33062cb2b9fcfbe0f5f351ed26c4d1e1581657deebd506b41ff7fdf89e787e3d33ce05854bc01686379b89e9c49b564c4cfa988efa
+  languageName: node
+  linkType: hard
+
 "acorn-walk@npm:^8.1.1":
   version: 8.3.3
   resolution: "acorn-walk@npm:8.3.3"
@@ -240,7 +247,9 @@ __metadata:
     "@actions/core": "npm:1.10.1"
     "@foxglove/tsconfig": "npm:2.0.0"
     "@types/node": "npm:22.0.2"
+    "@types/semver": "npm:7.5.8"
     jszip: "npm:3.10.1"
+    semver: "npm:7.6.3"
     ts-node: "npm:10.9.2"
     typescript: "npm:5.5.4"
   languageName: unknown
@@ -250,6 +259,15 @@ __metadata:
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
   checksum: 10c0/780ba6b5d99cc9a40f7b951d47152297d0e260f0df01472a1b99d4889679a4b94a13d644f7dbc4f022572f09ae9005fa2fbb93bbbd83643316f365a3e9a45b21
+  languageName: node
+  linkType: hard
+
+"semver@npm:7.6.3":
+  version: 7.6.3
+  resolution: "semver@npm:7.6.3"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/88f33e148b210c153873cb08cfe1e281d518aaa9a666d4d148add6560db5cd3c582f3a08ccb91f38d5f379ead256da9931234ed122057f40bb5766e65e58adaf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Changelog
None

### Docs

None

### Description

In #32, I added a CI check to validate that .foxe zip files actually use compression (a bug fixed in https://github.com/foxglove/create-foxglove-extension/pull/147). However, it turns out this check was broken because when loading a zip file with JSZip, `zipObj.options.compression` is not set even if the file was compressed. This PR replaces it with an alternative approach where we read the version of `create-foxglove-extension` from the extension's package.json and validate that it's >=1.0.3.