### PR TITLE
Add polygon-ros extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ Foxglove under the extension settings.
 - [Joint State Publisher](https://github.com/rogy-ken/foxglove-joint-state-publisher) - Publish joint state with slider UI.
 - [Teleop Twist Keyboard](https://github.com/usedhondacivic/foxglove-teleop-twist-keyboard) - A foxglove version of the ROS teleop_twist_keyboard node, used to publish Twist messages based on keyboard control.
 - [Orientation Panel 3D](https://github.com/peek-robotics/foxglove-orientation-panel-3d) - A simple 3D visualization of orientation from topics containing quaternions
+- [Polygon ROS](https://github.com/fireflyautomatix/foxglove-polygon-ros) - Visualize complex polygons

--- a/extensions.json
+++ b/extensions.json
@@ -243,5 +243,19 @@
     "sha256sum": "5970656242d2a41524f777ca2ab114f64838e8cf5c9644bb355710f1ba35613e",
     "foxe": "https://github.com/peek-robotics/foxglove-orientation-panel-3d/releases/download/v0.0.5/peekrobotics.orientation-panel-3d-0.0.5.foxe",
     "keywords": ["foxglove", "ros", "orientation", "quaternion"]
+  },
+  {
+    "id": "fireflyautomatix.polygon-ros",
+    "name": "Polygon ROS",
+    "description": "Visualize complex polygons",
+    "publisher": "Firefly Automatix",
+    "homepage": "https://github.com/fireflyautomatix/foxglove-polygon-ros",
+    "readme": "https://raw.githubusercontent.com/fireflyautomatix/foxglove-polygon-ros/refs/heads/main/README.md",
+    "changelog": "https://raw.githubusercontent.com/fireflyautomatix/foxglove-polygon-ros/refs/heads/main/CHANGELOG.md",
+    "license": "MIT",
+    "version": "1.0.0",
+    "sha256sum": "494d92c445cffecfd399f7b5425af3addaaa523a8bf3364a0f8d2ca79016ed42",
+    "foxe": "https://github.com/fireflyautomatix/foxglove-polygon-ros/releases/download/1.0.0/fireflyautomatix.polygon-ros-1.0.0.foxe",
+    "keywords": ["ros", "polygon", "2d"]
   }
 ]


### PR DESCRIPTION
Add Polygon ROS extension, which allows for visualizing complex polygons (polygons with holes) in the 3D view, via the polygon_ros (polygon_msgs) package.
