### PR TITLE
Add 2d orientation panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ Foxglove under the extension settings.
 - [Orientation Panel 3D](https://github.com/peek-robotics/foxglove-orientation-panel-3d) - A simple 3D visualization of orientation from topics containing quaternions
 - [String Panel](https://github.com/Ry0/foxglove-string-panel) - This extension displays the string data of std_msg/String or std_msg/msg/String on the panel.
 - [Polygon ROS](https://github.com/fireflyautomatix/foxglove-polygon-ros) - Visualize complex polygons
+- [Orientation Panel 2D](https://github.com/peek-robotics/foxglove-orientation-panel-2d) - A 2D visualization of orientation data from ROS messages with toggleable roll, pitch, and yaw displays

--- a/extensions.json
+++ b/extensions.json
@@ -282,8 +282,8 @@
     "changelog": "https://raw.githubusercontent.com/peek-robotics/foxglove-orientation-panel-2d/refs/heads/main/CHANGELOG.md",
     "license": "MIT",
     "version": "v0.0.5",
-    "sha256sum": "5970656242d2a41524f777ca2ab114f64838e8cf5c9644bb355710f1ba35613e",
-    "foxe": "https://github.com/peek-robotics/foxglove-orientation-panel-2d/releases/download/v0.0.5/peekrobotics.orientation-panel-2d-0.0.5.foxe",
+    "sha256sum": "79a3b24786a22f3e0cffbb8a92fb76aa8057e056270f230a8211c48387a2d0c5",
+    "foxe": "https://github.com/peek-robotics/foxglove-orientation-panel-2d/releases/download/v0.0.6/peekrobotics.orientation-panel-2d-0.0.6.foxe",
     "keywords": ["foxglove", "ros", "orientation", "quaternion", "roll", "pitch", "yaw"]
   }
 ]

--- a/extensions.json
+++ b/extensions.json
@@ -285,5 +285,5 @@
     "sha256sum": "5970656242d2a41524f777ca2ab114f64838e8cf5c9644bb355710f1ba35613e",
     "foxe": "https://github.com/peek-robotics/foxglove-orientation-panel-2d/releases/download/v0.0.5/peekrobotics.orientation-panel-2d-0.0.5.foxe",
     "keywords": ["foxglove", "ros", "orientation", "quaternion", "roll", "pitch", "yaw"]
-  },
+  }
 ]

--- a/extensions.json
+++ b/extensions.json
@@ -282,7 +282,7 @@
     "changelog": "https://raw.githubusercontent.com/peek-robotics/foxglove-orientation-panel-2d/refs/heads/main/CHANGELOG.md",
     "license": "MIT",
     "version": "v0.0.5",
-    "sha256sum": "79a3b24786a22f3e0cffbb8a92fb76aa8057e056270f230a8211c48387a2d0c5",
+    "sha256sum": "6f842196c4b0fb62c7b5350dbda05b7253d9a9bcb2779c218ef8bb8e047c63db",
     "foxe": "https://github.com/peek-robotics/foxglove-orientation-panel-2d/releases/download/v0.0.6/peekrobotics.orientation-panel-2d-0.0.6.foxe",
     "keywords": ["foxglove", "ros", "orientation", "quaternion", "roll", "pitch", "yaw"]
   }

--- a/extensions.json
+++ b/extensions.json
@@ -271,5 +271,19 @@
     "sha256sum": "494d92c445cffecfd399f7b5425af3addaaa523a8bf3364a0f8d2ca79016ed42",
     "foxe": "https://github.com/fireflyautomatix/foxglove-polygon-ros/releases/download/1.0.0/fireflyautomatix.polygon-ros-1.0.0.foxe",
     "keywords": ["ros", "polygon", "2d"]
-  }
+  },
+  {
+    "id": "peekrobotics.orientation-panel-2d",
+    "name": "Orientation Panel 2D",
+    "description": "A 2D visualization of orientation data from ROS messages with toggleable roll, pitch, and yaw displays",
+    "publisher": "peek-robotics",
+    "homepage": "https://github.com/peek-robotics/foxglove-orientation-panel-2d",
+    "readme": "https://raw.githubusercontent.com/peek-robotics/foxglove-orientation-panel-2d/refs/heads/main/README.md",
+    "changelog": "https://raw.githubusercontent.com/peek-robotics/foxglove-orientation-panel-2d/refs/heads/main/CHANGELOG.md",
+    "license": "MIT",
+    "version": "v0.0.5",
+    "sha256sum": "5970656242d2a41524f777ca2ab114f64838e8cf5c9644bb355710f1ba35613e",
+    "foxe": "https://github.com/peek-robotics/foxglove-orientation-panel-2d/releases/download/v0.0.5/peekrobotics.orientation-panel-2d-0.0.5.foxe",
+    "keywords": ["foxglove", "ros", "orientation", "quaternion", "roll", "pitch", "yaw"]
+  },
 ]


### PR DESCRIPTION
### Changelog

Added 2D orientation panel
### Docs

None
### Description

Needed a nice way to quickly visualize whether my IMUs were all in agreement. This panel is quite useful for displaying orientation of multiple sensors
