### PR TITLE
Added WrenchStamped panel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,4 @@ Foxglove under the extension settings.
 - [String Panel](https://github.com/Ry0/foxglove-string-panel) - This extension displays the string data of std_msg/String or std_msg/msg/String on the panel.
 - [Polygon ROS](https://github.com/fireflyautomatix/foxglove-polygon-ros) - Visualize complex polygons
 - [Orientation Panel 2D](https://github.com/peek-robotics/foxglove-orientation-panel-2d) - A 2D visualization of orientation data from ROS messages with toggleable roll, pitch, and yaw displays
+- [WrenchStamped Panel](https://github.com/Ry0/foxglove-wrench-stamped-panel) - This extension displays the string data of geometry_msgs/WrenchStamped.msg or geometry_msgs/msg/WrenchStamped.msg on the panel.

--- a/extensions.json
+++ b/extensions.json
@@ -285,5 +285,19 @@
     "sha256sum": "6f842196c4b0fb62c7b5350dbda05b7253d9a9bcb2779c218ef8bb8e047c63db",
     "foxe": "https://github.com/peek-robotics/foxglove-orientation-panel-2d/releases/download/v0.0.6/peekrobotics.orientation-panel-2d-0.0.6.foxe",
     "keywords": ["foxglove", "ros", "orientation", "quaternion", "roll", "pitch", "yaw"]
+  },
+  {
+    "id": "kabu.wrench-stamped-panel",
+    "name": "WrenchStamped Panel",
+    "description": "This extension displays the string data of geometry_msgs/WrenchStamped.msg or geometry_msgs/msg/WrenchStamped.msg on the panel.",
+    "publisher": "Ryo Kabutan",
+    "homepage": "https://github.com/Ry0/foxglove-wrench-stamped-panel",
+    "readme": "https://raw.githubusercontent.com/Ry0/foxglove-wrench-stamped-panel/refs/heads/master/README.md",
+    "changelog": "https://raw.githubusercontent.com/Ry0/foxglove-wrench-stamped-panel/refs/heads/master/CHANGELOG.md",
+    "license": "MIT",
+    "version": "v1.0.0",
+    "sha256sum": "bd58c28ddcca54467570dc7e646e209f6e4238f94d116eb3288b4bac9940e832",
+    "foxe": "https://github.com/Ry0/foxglove-wrench-stamped-panel/releases/download/v1.0.0/kabu.wrench-stamped-panel-1.0.0.foxe",
+    "keywords": ["foxglove", "ros", "wrench"]
   }
 ]


### PR DESCRIPTION
I have created the panel that visualize to WrenchStamped.msg.
https://docs.ros2.org/foxy/api/geometry_msgs/msg/WrenchStamped.html

It cannot be overlaid on the standard 3D panel, so I used a separate panel, to display it.
(If there is a way to implement this, please let me know.)
Actually, I am thinking that an official feature should be provided that allows Wrench data to be overlaid on the 3D panel.

I made it match the display in Rviz.
https://github.com/user-attachments/assets/4b5fdd5b-4b9b-4d0a-994c-dc39a42dc8b8


