### PR TITLE
Add LogMessageViewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ Foxglove under the extension settings.
 - [Polygon ROS](https://github.com/fireflyautomatix/foxglove-polygon-ros) - Visualize complex polygons
 - [Orientation Panel 2D](https://github.com/peek-robotics/foxglove-orientation-panel-2d) - A 2D visualization of orientation data from ROS messages with toggleable roll, pitch, and yaw displays
 - [WrenchStamped Panel](https://github.com/Ry0/foxglove-wrench-stamped-panel) - This extension displays the string data of geometry_msgs/WrenchStamped.msg or geometry_msgs/msg/WrenchStamped.msg on the panel.
+- [LogMessageViewer Panel](https://github.com/flypyka/foxglove-extensions) - Displays any foxglove.Log messages received during the entire displayed timeline.

--- a/extensions.json
+++ b/extensions.json
@@ -299,5 +299,19 @@
     "sha256sum": "bd58c28ddcca54467570dc7e646e209f6e4238f94d116eb3288b4bac9940e832",
     "foxe": "https://github.com/Ry0/foxglove-wrench-stamped-panel/releases/download/v1.0.0/kabu.wrench-stamped-panel-1.0.0.foxe",
     "keywords": ["foxglove", "ros", "wrench"]
+  },
+  {
+    "id": "pykainc.LogMessageViewer",
+    "name": "Log Message Viewer Panel",
+    "description": "Displays any foxglove.Log messages received during the entire displayed timeline. Allows filtering based on severity and contents. Clicking a message jumps the playhead to that timestamp.",
+    "publisher": "Pyka, Inc.",
+    "homepage": "https://github.com/flypyka/foxglove-extensions",
+    "readme": "https://raw.githubusercontent.com/flypyka/foxglove-extensions/refs/tags/v0.0.1/LogMessageViewer/README.md",
+    "changelog": "https://raw.githubusercontent.com/flypyka/foxglove-extensions/refs/tags/v0.0.1/LogMessageViewer/CHANGELOG.md",
+    "license": "MIT",
+    "version": "v0.0.1",
+    "sha256sum": "0373a32186670b0d7603bb0e49476ad89a5aef5eee96df7f86735ad002fa5ca0",
+    "foxe": "https://github.com/flypyka/foxglove-extensions/releases/download/v0.0.1/pykainc.LogMessageViewer-0.0.1.foxe",
+    "keywords": ["foxglove", "text", "log"]
   }
 ]


### PR DESCRIPTION
Adds an extension that displays any foxglove.Log messages received during the entire displayed timeline. Allows filtering based on severity and contents. Clicking a message jumps the playhead to that timestamp
