### PR TITLE
Add Flight Indicators extension by zalandemeter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Foxglove under the extension settings.
 - [Button](https://github.com/adityakamath/foxglove_extensions/tree/main/button) - Configurable toggle/push button that publishes std_msgs/Bool on a topic or calls a std_srvs/SetBool service on state change
 - [cap](https://github.com/kylerniemann/cap) - Foxglove extension for historical ROS bag and MCAP scene search, snippets, camera previews, and click-to-seek results
 - [Depth RVL Decoder](https://github.com/makeecat/foxglove-depth-rvl) - Foxglove schema converter that turns RVL compressed depth images into sensor_msgs/Image depth frames.
+- [Flight Indicators](https://github.com/zalandemeter/foxglove-flight-indicators) - Six classic aviation instrument panels — airspeed, altimeter, attitude, heading, turn coordinator, and variometer
 - [Gauge Utils](https://github.com/PuYuuu/foxglove-gauge-extension/) - Visualize vehicle data with customizable gauges: speedometer, steering wheel, and time series charts
 - [H264 Video Playback](https://github.com/codewithpassion/foxglove-studio-h264-extension) - Experimental H264 video playback
 - [Isaac Powerpack](https://github.com/isaac-powerpack/pow) – A collection of tools for visualizing and debugging Isaac ROS data

--- a/extensions.json
+++ b/extensions.json
@@ -696,5 +696,26 @@
       "recording",
       "bag"
     ]
+  },
+  {
+    "id": "zalandemeter.flight-indicators",
+    "name": "Flight Indicators",
+    "description": "Six classic aviation instrument panels for Foxglove Studio — airspeed, altimeter, attitude, heading, turn coordinator, and variometer.",
+    "publisher": "Zalán Demeter",
+    "homepage": "https://github.com/zalandemeter/foxglove-flight-indicators",
+    "readme": "https://raw.githubusercontent.com/zalandemeter/foxglove-flight-indicators/main/README.md",
+    "changelog": "https://raw.githubusercontent.com/zalandemeter/foxglove-flight-indicators/main/CHANGELOG.md",
+    "license": "MIT",
+    "version": "1.0.0",
+    "sha256sum": "05526c9da7962d6f8894f800b161adcbc68ccc7fb7b2a0ba038e0666f64d1ae4",
+    "foxe": "https://github.com/zalandemeter/foxglove-flight-indicators/releases/download/v1.0.0/zalandemeter.flight-indicators-1.0.0.foxe",
+    "keywords": [
+      "aviation",
+      "flight",
+      "instrument",
+      "UAV",
+      "ROS",
+      "ROS2"
+    ]
   }
 ]


### PR DESCRIPTION
### Changelog
New extension: Flight Indicators — six classic aviation instrument panels (airspeed, altimeter, attitude, heading, turn coordinator, variometer) for real-time flight data visualization.

### Docs
[README.md](https://github.com/zalandemeter/foxglove-flight-indicators/blob/main/README.md)

### Description
Adds the [Flight Indicators](https://github.com/zalandemeter/foxglove-flight-indicators) extension to the public registry.

This extension provides the complete classic six-pack of aviation instruments as native Foxglove Studio panels, targeted at UAV developers, experimental aircraft builders, and flight simulation rigs. Each panel uses Foxglove's built-in message path input with autocomplete, so it works with any message type — `std_msgs/Float64`, custom ROS schemas, or any data source that resolves to a numeric field. No custom message definitions are required.

Instruments are rendered using [flight-indicators-js](https://github.com/teocci/js-module-flight-indicators) (MIT). All SVG assets are inlined as data URLs so the extension is fully self-contained as a single bundle.

Manual testing performed: installed `.foxe` locally via Foxglove desktop on Windows, connected a ROS 2 Jazzy data source via `foxglove_bridge`, configured message paths on all six panels, and verified correct instrument behavior across the full value range for each panel.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

No dedicated aviation instrument panels available in the Foxglove extension registry.

</td><td>

Six panels available for install directly from Foxglove Studio settings — Airspeed Indicator, Altimeter, Attitude Indicator, Heading Indicator, Turn Coordinator, and Variometer.

</td></tr></table>
