### PR TITLE
Add ASLZ Control Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Foxglove under the extension settings.
 - [Blank Panel](https://github.com/foxglove/blank-panel-extension) – Add a little space to your layout
 - [Button](https://github.com/adityakamath/foxglove_extensions/tree/main/button) - Configurable toggle/push button that publishes std_msgs/Bool on a topic or calls a std_srvs/SetBool service on state change
 - [cap](https://github.com/kylerniemann/cap) - Foxglove extension for historical ROS bag and MCAP scene search, snippets, camera previews, and click-to-seek results
+- [Control Extension](https://github.com/XENONFFM/foxglove-control-extension) - Foxglove panels for remote control using a gampad/joystick/keyboard.
 - [Depth RVL Decoder](https://github.com/makeecat/foxglove-depth-rvl) - Foxglove schema converter that turns RVL compressed depth images into sensor_msgs/Image depth frames.
 - [Flight Indicators](https://github.com/zalandemeter/foxglove-flight-indicators) - Six classic aviation instrument panels — airspeed, altimeter, attitude, heading, turn coordinator, and variometer
 - [Gauge Utils](https://github.com/PuYuuu/foxglove-gauge-extension/) - Visualize vehicle data with customizable gauges: speedometer, steering wheel, and time series charts

--- a/extensions.json
+++ b/extensions.json
@@ -728,7 +728,7 @@
     "changelog": "https://github.com/XENONFFM/foxglove-joystick/blob/main/CHANGELOG.md",
     "license": "MIT",
     "version": "1.0.0.beta6",
-    "sha256sum": "sha256:a2c3007f221c7a779132d6a5d39b562b8631a67a2960f57287de2f6e8d7fcb41",
+    "sha256sum": "a2c3007f221c7a779132d6a5d39b562b8631a67a2960f57287de2f6e8d7fcb41",
     "foxe": "https://github.com/XENONFFM/foxglove-control-extension/releases/download/v1.0.0-beta.6/xenonffm.control-extension-1.0.0-beta.6.foxe",
     "keywords": [
       "joystick",

--- a/extensions.json
+++ b/extensions.json
@@ -717,5 +717,31 @@
       "ROS",
       "ROS2"
     ]
+  },
+  {
+    "id": "aslz.control-extension",
+    "name": "Control Extension",
+    "description": "Foxglove panels for remote control using a gampad/joystick/keyboard.",
+    "publisher": "XENONFFM (ASLZ)",
+    "homepage": "https://github.com/XENONFFM/foxglove-joystick",
+    "readme": "https://github.com/XENONFFM/foxglove-joystick/blob/main/README.md",
+    "changelog": "https://github.com/XENONFFM/foxglove-joystick/blob/main/CHANGELOG.md",
+    "license": "MIT",
+    "version": "1.0.0.beta6",
+    "sha256sum": "sha256:a2c3007f221c7a779132d6a5d39b562b8631a67a2960f57287de2f6e8d7fcb41",
+    "foxe": "https://github.com/XENONFFM/foxglove-control-extension/releases/download/v1.0.0-beta.6/xenonffm.control-extension-1.0.0-beta.6.foxe",
+    "keywords": [
+      "joystick",
+      "touch",
+      "gamepad",
+      "keyboard",
+      "remote",
+      "control",
+      "twist",
+      "joy",
+      "teleop",
+      "ros",
+      "ros2"
+    ]
   }
 ]


### PR DESCRIPTION
### Changelog
**New extension:** [ASLZ Control Extension](https://github.com/XENONFFM/foxglove-control-extension/tree/main) - Foxglove panels for remote control using a gampad/joystick/keyboard. [(Documentation)](https://github.com/XENONFFM/foxglove-control-extension/blob/main/README.md)

