### PR TITLE
Add System Health panel by bensaar

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Foxglove under the extension settings.
 - [ROS2 Graph](https://github.com/polymathrobotics/foxglove_extensions/tree/main/ros2-graph) - Visualization and information on nodes, topics and other ROS2 Graph data (requires running [Graph Monitor](https://github.com/ros-tooling/graph-monitor))
 - [ROS2 Parameters](https://github.com/danclapp4/ros2-parameter-extension) - Interact with ROS2 Parameters
 - [SidewaysTeleop](https://github.com/rscova/foxglove-sideways-teleop-extension) – Use an Xbox controller to control a robot
-- [String Panel](https://github.com/Ry0/foxglove-string-panel) - This extension displays the string data of std_msg/String or std_msg/msg/String on the panel.
+- [String Panel](https://github.com/Ry0/foxglove-string-panel)
+- [System Health](https://github.com/BenSaarAB/foxglove_panels) - Compact health badge grid for system submodules - This extension displays the string data of std_msg/String or std_msg/msg/String on the panel.
 - [Teleop Twist Keyboard](https://github.com/usedhondacivic/foxglove-teleop-twist-keyboard) - A foxglove version of the ROS teleop_twist_keyboard node, used to publish Twist messages based on keyboard control.
 - [Virtual Joystick](https://github.com/yulong88888/foxglove-nipple) - Easier to use twist topic publisher
 - [Webcam](https://github.com/joshnewans/foxglove-webcam) - Republish webcam data into ROS

--- a/extensions.json
+++ b/extensions.json
@@ -728,7 +728,7 @@
     "changelog": "https://raw.githubusercontent.com/BenSaarAB/foxglove_panels/main/system-health/CHANGELOG.md",
     "license": "MIT",
     "version": "0.1.0",
-    "sha256sum": "66db2afc83d452977d3ee47c844d2ed38e61c124b26667dd6e1459fb0bbce393",
+    "sha256sum": "b20358a9906c95351ae02e088b95cb74c29206fb5d6b4eebd3f805f17a9b7241",
     "foxe": "https://github.com/BenSaarAB/foxglove_panels/releases/download/v0.1.0/bensaar.system-health-0.1.0.foxe",
     "keywords": [
       "health",

--- a/extensions.json
+++ b/extensions.json
@@ -719,6 +719,27 @@
     ]
   },
   {
+    "id": "bensaar.system-health",
+    "name": "System Health",
+    "description": "Compact health badge grid for system submodules",
+    "publisher": "bensaar",
+    "homepage": "https://github.com/BenSaarAB/foxglove_panels",
+    "readme": "https://raw.githubusercontent.com/BenSaarAB/foxglove_panels/main/system-health/README.md",
+    "changelog": "https://raw.githubusercontent.com/BenSaarAB/foxglove_panels/main/system-health/CHANGELOG.md",
+    "license": "MIT",
+    "version": "0.1.0",
+    "sha256sum": "66db2afc83d452977d3ee47c844d2ed38e61c124b26667dd6e1459fb0bbce393",
+    "foxe": "https://github.com/BenSaarAB/foxglove_panels/releases/download/v0.1.0/bensaar.system-health-0.1.0.foxe",
+    "keywords": [
+      "health",
+      "diagnostics",
+      "l4",
+      "ros",
+      "ros2",
+      "autonomous"
+    ]
+  },
+  {
     "id": "aslz.control-extension",
     "name": "Control Extension",
     "description": "Foxglove panels for remote control using a gampad/joystick/keyboard.",


### PR DESCRIPTION
## Summary

Adds the [System Health](https://github.com/BenSaarAB/foxglove_panels) panel — a compact, auto-scaling badge grid for monitoring the health of system submodules in real time.

All modules are fully user-configurable via the Foxglove panel settings editor, with no hardcoded topic names.

## Features

- **Fully configurable module list** — add, remove, and label any number of modules via the settings panel
- **Four monitoring modes per module:**
  - `diagnostics` — reads OK/WARN/ERROR/STALE levels and Hz rate from `/diagnostics` using `<prefix>: <topic>` entry names (compatible with `health_monitor`, `diagnostic_aggregator`, etc.)
  - `heartbeat` — marks OK whenever any message arrives on the topic; works with any topic, no diagnostic node required
  - `diag-name` — looks up a diagnostic entry by its exact name and displays a configurable value key (e.g. for RAM/CPU monitors)
  - `diag-hardware-id` — filters diagnostic entries by `hardware_id` and shows worst level with optional primary/secondary value display
- **Auto-scaling badges** — grid fills available panel space at any size, with color-coded OK/WARN/ERROR/STALE states
- **Stale detection** — modules that stop publishing automatically turn grey
- **Persistent settings** — configuration is saved per-panel layout
- **Configurable** diagnostic prefix, frequency key, cache timeout, and stale threshold

## Links

- **Source:** https://github.com/BenSaarAB/foxglove_panels/tree/main/system-health
- **README:** https://github.com/BenSaarAB/foxglove_panels/blob/main/system-health/README.md
- **Release:** https://github.com/BenSaarAB/foxglove_panels/releases/tag/v0.1.0

## Test plan

- [ ] Verify `.foxe` URL is accessible
- [ ] Install extension in Foxglove and confirm panel loads
- [ ] Add a module in each mode via the settings panel
- [ ] Confirm `extensions.json` entry is valid JSON
- [ ] Confirm README entry is alphabetically ordered

🤖 Generated with [Claude Code](https://claude.com/claude-code)