### PR TITLE
Update Autoware Foxglove Extensions to v0.1.4

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -208,9 +208,9 @@
     "readme": "https://raw.githubusercontent.com/tier4/AutowareFoxgloveExtensions/main/README.md",
     "changelog": "https://raw.githubusercontent.com/tier4/AutowareFoxgloveExtensions/main/CHANGELOG.md",
     "license": "Apache 2.0",
-    "version": "0.1.3",
-    "sha256sum": "cb182276f8747c27841839a89a58a82b11e85c3177d36ac83217dfbffe186c57",
-    "foxe": "https://github.com/tier4/AutowareFoxgloveExtensions/releases/download/v0.1.3/tier4.autoware-foxglove-extensions-0.1.3.foxe",
+    "version": "0.1.4",
+    "sha256sum": "ee5cf6602d787fb3a05892bfda1c0edca09740186541716d108bf0249dd261db",
+    "foxe": "https://github.com/tier4/AutowareFoxgloveExtensions/releases/download/v0.1.4/tier4.autoware-foxglove-extensions-0.1.4.foxe",
     "keywords": [
       "ros",
       "autoware"


### PR DESCRIPTION
Bumps `tier4.autoware-foxglove-extensions` from `0.1.3` to `0.1.4`.

## What's changed in v0.1.4
- Align `ObjectClassification` labels with `autoware_perception_msgs` ([tier4/AutowareFoxgloveExtensions#9](https://github.com/tier4/AutowareFoxgloveExtensions/pull/9))

Release notes: https://github.com/tier4/AutowareFoxgloveExtensions/releases/tag/v0.1.4
Full diff: https://github.com/tier4/AutowareFoxgloveExtensions/compare/v0.1.3...v0.1.4