### PR TITLE
Add Joystick Connector extension by zalandemeter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Foxglove under the extension settings.
 - [H264 Video Playback](https://github.com/codewithpassion/foxglove-studio-h264-extension) - Experimental H264 video playback
 - [Isaac Powerpack](https://github.com/isaac-powerpack/pow) – A collection of tools for visualizing and debugging Isaac ROS data
 - [Joint State Publisher](https://github.com/rogy-ken/foxglove-joint-state-publisher) - Publish joint state with slider UI.
+- [Joystick Connector](https://github.com/zalandemeter/foxglove-joystick-connector) - Publish sensor_msgs/msg/Joy from a physical gamepad or a virtual on-screen joystick
 - [Joystick/gamepad control](https://github.com/joshnewans/foxglove-joystick) - Receive/monitor/generate joystick and gamepad controls
 - [LogMessageViewer Panel](https://github.com/flypyka/foxglove-extensions) - Displays any foxglove.Log messages received during the entire displayed timeline.
 - [Markdown](https://github.com/polymathrobotics/foxglove_extensions/tree/main/markdown) - Basic markdown renderer extension for documentation and notes

--- a/extensions.json
+++ b/extensions.json
@@ -677,6 +677,27 @@
     ]
   },
   {
+    "id": "zalandemeter.joystick-connector",
+    "name": "Joystick Connector",
+    "description": "Publish sensor_msgs/msg/Joy from a physical gamepad or a virtual on-screen joystick.",
+    "publisher": "zalandemeter",
+    "homepage": "https://github.com/zalandemeter/foxglove-joystick-connector",
+    "readme": "https://raw.githubusercontent.com/zalandemeter/foxglove-joystick-connector/main/README.md",
+    "changelog": "https://raw.githubusercontent.com/zalandemeter/foxglove-joystick-connector/main/CHANGELOG.md",
+    "license": "MIT",
+    "version": "1.0.0",
+    "sha256sum": "cf91c72d121167440d4f41a7d9ad51003a8eaf214d0d511453ad979ca7e25923",
+    "foxe": "https://github.com/zalandemeter/foxglove-joystick-connector/releases/download/v1.0.0/zalandemeter.joystick-connector-1.0.0.foxe",
+    "keywords": [
+      "ros",
+      "joystick",
+      "gamepad",
+      "joy",
+      "control",
+      "interactive"
+    ]
+  },
+  {
     "id": "qraftyai.foxglove-recorder-ui",
     "name": "MCAP Recorder",
     "description": "Control MCAP recording sessions with ROS2 integration",


### PR DESCRIPTION
### Changelog
  New extension: Joystick Connector — publish `sensor_msgs/msg/Joy` from a physical gamepad or a virtual
  on-screen joystick directly from Foxglove Studio.

  ### Docs
  [README.md](https://github.com/zalandemeter/foxglove-joystick-connector/blob/main/README.md)

  ### Description
  Adds the [Joystick Connector](https://github.com/zalandemeter/foxglove-joystick-connector) extension to
  the public registry.

  This extension publishes `sensor_msgs/msg/Joy` directly from Foxglove Studio — either from a physical
  gamepad via the browser Gamepad API, or from a built-in virtual joystick with configurable axes and
  buttons. It targets UAV operators, robot developers, and simulation users who need to inject joystick
  input without leaving the Foxglove environment.

  Key features: auto device mode (claims the first available unclaimed gamepad, falls back to virtual),
  multi-panel coordination (each panel owns a unique device and topic, conflicts shown as warnings),
  compact LED mode for small panel tiles, and configurable publish rate (1–200 Hz). No custom message
  definitions required — output is standard `sensor_msgs/msg/Joy`.

  Manual testing performed: installed `.foxe` locally via Foxglove desktop on Linux, connected a
  Thrustmaster T.16000M joystick, verified axis and button mirroring across the full range, tested virtual
  joystick sliders and button grid, and confirmed `sensor_msgs/msg/Joy` delivery over a live ROS 2 Jazzy
  connection via `foxglove_bridge`.

  <table><tr><th>Before</th><th>After</th></tr><tr><td>

  No panel in the Foxglove extension registry for publishing `sensor_msgs/msg/Joy` from a physical gamepad
  with multi-panel coordination and a virtual fallback.

  </td><td>

  Joystick Connector available for install directly from Foxglove Studio settings — supports physical
  gamepads via the Gamepad API and a configurable virtual joystick, with conflict resolution when multiple
  panels are open.

  </td></tr></table>