### PR TITLE
Add ros2_medkit Diagnostics extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Foxglove under the extension settings.
 - [PX4 Converter](https://github.com/foxglove/px4_converter) - Extended visualization of PX4 messages in Foxglove panels
 - [ROS2 Graph](https://github.com/polymathrobotics/foxglove_extensions/tree/main/ros2-graph) - Visualization and information on nodes, topics and other ROS2 Graph data (requires running [Graph Monitor](https://github.com/ros-tooling/graph-monitor))
 - [ROS2 Parameters](https://github.com/danclapp4/ros2-parameter-extension) - Interact with ROS2 Parameters
+- [ros2_medkit Diagnostics](https://github.com/selfpatch/ros2_medkit_foxglove_extension) - Turn ROS 2 failures into structured faults on a SOVD entity tree, over the ros2_medkit gateway
 - [SidewaysTeleop](https://github.com/rscova/foxglove-sideways-teleop-extension) – Use an Xbox controller to control a robot
 - [String Panel](https://github.com/Ry0/foxglove-string-panel) - This extension displays the string data of std_msg/String or std_msg/msg/String on the panel.
 - [Teleop Twist Keyboard](https://github.com/usedhondacivic/foxglove-teleop-twist-keyboard) - A foxglove version of the ROS teleop_twist_keyboard node, used to publish Twist messages based on keyboard control.

--- a/extensions.json
+++ b/extensions.json
@@ -764,5 +764,26 @@
       "ros",
       "ros2"
     ]
+  },
+  {
+    "id": "selfpatch.ros2-medkit-foxglove-extension",
+    "name": "ros2_medkit Diagnostics",
+    "description": "Turn ROS 2 failures into structured faults on a SOVD entity tree, with live fault streaming, topic/operation access, parameter editing and lifecycle control",
+    "publisher": "selfpatch",
+    "homepage": "https://github.com/selfpatch/ros2_medkit_foxglove_extension",
+    "readme": "https://raw.githubusercontent.com/selfpatch/ros2_medkit_foxglove_extension/main/README.md",
+    "changelog": "https://raw.githubusercontent.com/selfpatch/ros2_medkit_foxglove_extension/main/CHANGELOG.md",
+    "license": "Apache-2.0",
+    "version": "0.6.0",
+    "sha256sum": "51d0f1ceccc9a6f1d23f2526bdcdf32b5afaeb61c6dd9fc1209ca10ef8ed35e3",
+    "foxe": "https://github.com/selfpatch/ros2_medkit_foxglove_extension/releases/download/v0.6.0/selfpatch.ros2-medkit-foxglove-extension-0.6.0.foxe",
+    "keywords": [
+      "ros2",
+      "ros",
+      "medkit",
+      "diagnostics",
+      "sovd",
+      "faults"
+    ]
   }
 ]


### PR DESCRIPTION
### Changelog
New extension: ros2_medkit Diagnostics - turn ROS 2 failures into structured
faults on a SOVD entity tree, with live data, operations, parameters and
lifecycle, over the ros2_medkit gateway.

### Docs
[README.md](https://github.com/selfpatch/ros2_medkit_foxglove_extension/blob/main/README.md)

### Description
Adds the [ros2_medkit Diagnostics](https://github.com/selfpatch/ros2_medkit_foxglove_extension)
extension to the public registry.

The panels bring the [ros2_medkit](https://github.com/selfpatch/ros2_medkit)
gateway - a SOVD-aligned REST/SSE diagnostics API for ROS 2 - inside Foxglove
Studio. Without leaving Foxglove you can browse the SOVD entity tree (areas ->
components -> apps), read and publish topics, run service/action operations, edit
ROS 2 parameters, watch structured faults stream in live (SSE), control entity
lifecycle, and inspect the gateway (version, capabilities, API entry points). It
targets ROS 2 developers and operators who already use Foxglove and want
structured diagnostics next to their data.

- Release: https://github.com/selfpatch/ros2_medkit_foxglove_extension/releases/tag/v0.6.0
- License: Apache-2.0

Note: this is the extension's first release in the registry. The ros2_medkit
projects (gateway, web UI, MCP, generated clients, and this extension) are
versioned together, so it starts at 0.6.0 to match the gateway it targets rather
than at 0.1.0.

Manual testing: installed the `.foxe` in Foxglove Studio against a running
ros2_medkit gateway and verified the entity tree and its resource tabs, live
fault streaming in the Faults Dashboard, the lifecycle control, and Server Info.
